### PR TITLE
do not fail on the first inaccessible input device

### DIFF
--- a/shared/configeditor/src/XmlReader.cpp
+++ b/shared/configeditor/src/XmlReader.cpp
@@ -960,7 +960,7 @@ int XmlReader::ReadConfigFile(string filePath)
     {
       if(m_evtcatch->init() < 0)
       {
-        m_error = "can't read inputs!";
+        m_error = "No accessible input(s) found.";
         return -1;
       }
     }

--- a/shared/gasync/src/input/linux/mkb.c
+++ b/shared/gasync/src/input/linux/mkb.c
@@ -336,8 +336,7 @@ int mkb_init(const GPOLL_INTERFACE * poll_interface, int (*callback)(GE_Event*))
       }
       else
       {
-        PRINT_ERROR_ERRNO("open")
-        ret = -1;
+        PRINT_ERROR_ERRNO("opening input device");
       }
 
       free(namelist[i]);
@@ -347,6 +346,11 @@ int mkb_init(const GPOLL_INTERFACE * poll_interface, int (*callback)(GE_Event*))
   else
   {
     PRINT_ERROR_ERRNO("scandir")
+    ret = -1;
+  }
+
+  if(max_device_id == -1) {
+    PRINT_ERROR_OTHER("no accessible device(s) found");
     ret = -1;
   }
 


### PR DESCRIPTION
I wanted to use GIMX on an Acer TravelMate running Ubuntu 16.04 LTS and got the message "can't read inputs!".

Digging in the source, and using the console output and `strace` the problem was found in `mkb.c`.

The function `mkb_init()` will iterate over all event devices found below `/dev/input` and will try to open each of them in turn. If **any** of the devices fails to `open()`, the function will return with error code -1, leading to the error message shown above.

After checking the permissions (e.g. `gimx-launcher` is sgid `input`, so permissions are fine) and even running the program as `root` the same error was popping up.

Some poking later the culprit was found. Acer laptops sport the `ACER BMA150 accelerometer`, which will be registered by the kernel as event and joystick device (check your `/var/log/Xorg.0.log` for **BMA150**, for me it was `/dev/input/event9` and `/dev/input/js0`) but lacking the capabilities. They can even not be read as `root`. They could be removed, but not permanently, as they will be recreated next time the X server starts.

The change in this PR will try to open each event device in turn and only report an error is absolutely no accessible event device is found. It has been tested working on an Acer Travelmate 6593.

Cheers,
Tempura

PS: Thank you for GIMX! :+1: 