### PR TITLE
Pull Request for extending Network API

### DIFF
--- a/core/calibration.c
+++ b/core/calibration.c
@@ -456,6 +456,40 @@ void cal_key(int sym, int down)
 #define DEADZONE_MAX(AXIS) \
     (controller_get_mean_unsigned(ctype, AXIS) / controller_get_axis_scale(ctype, AXIS) / 2)
 
+void cal_setSensibility(double s)
+{
+  s_mouse_cal* mcal = cal_get_mouse(current_mouse, current_conf);
+  double ratio = *mcal->my / *mcal->mx;
+  *mcal->mx = s;
+  *mcal->my = *mcal->mx * ratio;
+}
+
+void cal_setDeadzoneX(int dx)
+{
+  e_controller_type ctype = adapter_get(cal_get_controller(current_mouse))->ctype;
+  s_mouse_control* mc = cfg_get_mouse_control(current_mouse);
+  s_mouse_cal* mcal = cal_get_mouse(current_mouse, current_conf);
+  if (mcal->dzx && dx < DEADZONE_MAX(rel_axis_rstick_x)) {
+    *mcal->dzx = dx;
+    mc->merge[mc->index].x = 1;
+    mc->merge[mc->index].y = 0;
+    mc->change = 1;
+  }
+
+}
+void cal_setDeadzoneY(int dy)
+{
+  e_controller_type ctype = adapter_get(cal_get_controller(current_mouse))->ctype;
+  s_mouse_control* mc = cfg_get_mouse_control(current_mouse);
+  s_mouse_cal* mcal = cal_get_mouse(current_mouse, current_conf);
+  if (mcal->dzy && dy < DEADZONE_MAX(rel_axis_rstick_y)) {
+    *mcal->dzy = dy;
+    mc->merge[mc->index].x = 0;
+    mc->merge[mc->index].y = 1;
+    mc->change = 1;
+  }
+}
+
 /*
  * Use the mouse wheel to calibrate the mouse.
  */

--- a/core/calibration.c
+++ b/core/calibration.c
@@ -273,6 +273,24 @@ static void cal_display()
   }
 }
 
+void cal_save()
+{
+  current_cal = NONE;
+  if (cfgw_modify_file(gimx_params.config_file)) {
+    gwarn(_("error writting the config file %s\n"), gimx_params.config_file);
+  }
+  ginfo(_("calibration done\n"));
+}
+
+void cal_update_display()
+{
+  if (gimx_params.curses) {
+    display_calibration();
+  } else {
+    cal_display();
+  }
+}
+
 /*
  * Use keys to calibrate the mouse.
  */
@@ -319,12 +337,7 @@ void cal_key(int sym, int down)
           }
           else
           {
-            current_cal = NONE;
-            if (cfgw_modify_file(gimx_params.config_file))
-            {
-              gwarn(_("error writting the config file %s\n"), gimx_params.config_file);
-            }
-            ginfo(_("calibration done\n"));
+            cal_save();
           }
         }
         else if(current_cal != NONE)
@@ -442,14 +455,7 @@ void cal_key(int sym, int down)
 
   if(prev != current_cal)
   {
-    if(gimx_params.curses)
-    {
-      display_calibration();
-    }
-    else
-    {
-      cal_display();
-    }
+    cal_update_display();
   }
 }
 

--- a/core/controller.c
+++ b/core/controller.c
@@ -138,20 +138,33 @@ static void adapter_dump_state(int adapter)
   gstatus("\n");
 }
 
+static float float_swap(float x)
+{
+  union V {
+    float f;
+    uint32_t i;
+  };
+  union V val;
+  val.f = x;
+  val.i = htonl(val.i);
+  return val.f;
+}
+
 static void handlePacketConfig(const s_network_packet_config* buf)
 {
-  if (buf->sensibility < FLT_MAX) {
-    printf("setting sensibility=%f\n",buf->sensibility);
-    cal_setSensibility(buf->sensibility);
+  float s = float_swap(buf->sensibility);
+  if (s < FLT_MAX && s >= 0) {
+    printf("setting sensibility=%f\n", s);
+    cal_setSensibility(s);
   }
-  int16_t dx=ntohs(buf->dead_zone_X);
+  int16_t dx = ntohs(buf->dead_zone_X);
   if (dx < INT16_MAX) {
-    printf("setting dx=%d\n",dx);
+    printf("setting dx=%d\n", dx);
     cal_setDeadzoneX(dx);
   }
-  int16_t dy=ntohs(buf->dead_zone_Y);
+  int16_t dy = ntohs(buf->dead_zone_Y);
   if (dy < INT16_MAX) {
-    printf("setting dy=%d\n",dy);
+    printf("setting dy=%d\n", dy);
     cal_setDeadzoneY(dy);
   }
 }
@@ -161,7 +174,7 @@ static s_network_packet_config handlePacketGetConfig()
   s_network_packet_config config_pkg;
   const s_mouse_cal* mcal = cal_get_mouse(current_mouse, current_conf);
   config_pkg.packet_type = E_NETWORK_PACKET_GETCONFIG;
-  config_pkg.sensibility = *mcal->mx;
+  config_pkg.sensibility = float_swap(*mcal->mx);
   config_pkg.dead_zone_X = htons(*mcal->dzx);
   config_pkg.dead_zone_Y = htons(*mcal->dzy);
   return config_pkg;

--- a/core/controller.c
+++ b/core/controller.c
@@ -203,6 +203,9 @@ static int network_read_callback(void * user)
       adapters[adapter].send_command = 1;
     }
     break;
+  case E_NETWORK_PACKET_EXIT:
+      set_done(1);
+      break;
   }
   // require a report to be sent immediately, except for a Sixaxis controller working over bluetooth
   if(adapters[adapter].ctype == C_TYPE_SIXAXIS && adapters[adapter].atype == E_ADAPTER_TYPE_BLUETOOTH)

--- a/core/controller.c
+++ b/core/controller.c
@@ -263,6 +263,12 @@ static int network_read_callback(void * user)
     }
     break;
   }
+  case E_NETWORK_PACKET_SAVECALIBRATION:
+  {
+    cal_save();
+    cal_update_display();
+    break;
+  }
   default:
     gwarn("%s: packet_type not recognized",__func__);
   }

--- a/core/include/calibration.h
+++ b/core/include/calibration.h
@@ -41,5 +41,7 @@ void calibration_test();
 void cal_setSensibility(double);
 void cal_setDeadzoneX(int);
 void cal_setDeadzoneY(int);
+void cal_save();
+void cal_update_display();
 
 #endif /* CALIBRATION_H_ */

--- a/core/include/calibration.h
+++ b/core/include/calibration.h
@@ -38,5 +38,8 @@ void cal_init();
 int cal_get_controller(int);
 void cal_set_controller(int, int);
 void calibration_test();
+void cal_setSensibility(double);
+void cal_setDeadzoneX(int);
+void cal_setDeadzoneY(int);
 
 #endif /* CALIBRATION_H_ */


### PR DESCRIPTION
Related to issue #605.
This pull request adds the following network functionalities:

- Exit gimx.
- Get some configuration settings (ex: sensibility)
- Set some configuration settings
- Save current calibration/changed settings

See https://github.com/Lucashsmello/GIMX/wiki/Network-api-extended

### Notes: 

- When sending values through network, all should be in network byte order. 
- I found strange that in my testing machines, float values should be converted from network byte order. I thought that float values had common representation in all machines. There is a function named `float_swap` in `core/controller.c` that do the job.
- Get/Set configuration settings through network only get/change current profile. Changing profile will be implemented in a future commit. Probably on a new packet type.